### PR TITLE
add torch in seperate panel; remove 'time'

### DIFF
--- a/drive-contents/setup/watchshade.py
+++ b/drive-contents/setup/watchshade.py
@@ -5,7 +5,6 @@ import time
 import system
 from system import display
 
-
 import hardware
 import microcontroller
 
@@ -20,6 +19,8 @@ def _should_be_sys_reset():
 @singleinstance
 class shade(Pages):
     page = PageState(0)
+
+    temp_brightness = None
 
     open_stack = []
 
@@ -39,6 +40,15 @@ class shade(Pages):
             self.page = self.main_shade
         # print(self.open_stack)
 
+    def open_torch(self, page_to_open):
+        shade.temp_brightness = display.brightness._value
+        display.brightness.update(1.0)
+        self.open_page(page_to_open)
+
+    def pop_torch(self):
+        display.brightness.update(shade.temp_brightness)
+        self.pop_view()
+
     @singleinstance
     class main_shade(Layout):
 
@@ -47,38 +57,43 @@ class shade(Pages):
         open_time = Button(
             text="time",
             radius=ratio(height // 2),
-            press=self._superior_.open_page(self._superior_.time_panel),
+            #press=self._superior_.open_page(self._superior_.time_panel),
+            press=self._superior_.pop_view(),
+        )
+
+        open_torch = Button(
+            text="torch",
+            radius=ratio(height // 2),
+            press=self._superior_.open_torch(self._superior_.torch_panel),
         )
 
         reset = Button(text="Reset", press=_should_be_sys_reset)
 
         def _wearable_(self):
             slider = self.slider((center, top), (self.width, self.height // 4))
+
             open_time = self.open_time(
                 (left, center),
-                (115, 59),
+                (self.width // 2, self.height // 4),
             )
+
             # done = self.done((center, bottom), (self.width, self.height // 4))
             reset = self.reset((right, center), (self.width // 2, self.height // 4))
+            open_torch = self.open_torch(
+                (left, below(reset)),
+                (self.width // 2, self.height // 4),
+            )
 
         def close_shade(self):
             self._superior_.pop_view()
 
     @singleinstance
-    class time_panel(Layout):
-        back = Button(text="<", press=self._superior_.pop_view())
-        fill = State(color.red)
+    class torch_panel(Layout):
+        back = Button(text="<", press=self._superior_.pop_torch())
+        fill = State(color.white)
 
         rect = Rect(fill=fill)
-        but1 = Button(text="Calc", press=self.set_color(color.blue))
-        but2 = Button(text="Calc", press=self.set_color(color.green))
 
         def _any_(self):
+            r = self.rect((0,0), (self.height, self.width))
             back = self.back((left, top), (self.width // 4, self.height // 4))
-            size = (self.width // 2, self.height // 2)
-            b1 = self.but1((left, bottom), size)
-            b2 = self.but2((right, bottom), size)
-            r = self.rect((rightof(back), top), size)
-
-        def set_color(self, color):
-            self.fill = color


### PR DESCRIPTION
Not the most useful feature, but it's neat and it works. I think it saves a _little_ RAM over the "time" panel that I had to drop to get it to fit. It still has a minor issue (not catastrophic, just not intended), but I believe it requires internal changes before it can be fixed. The brightness doesn't revert when the watch shade is dismissed without exiting the panel.