### PR TITLE
optimize `self._superior_` for lower memory usage

### DIFF
--- a/drive-contents/tg_gui_core/attribute_specifier.py
+++ b/drive-contents/tg_gui_core/attribute_specifier.py
@@ -137,4 +137,4 @@ class ForwardMethodCall:
 
 # for import
 self = SpecifierConstructor()
-superior = self._superior_
+self._superior_ = AttributeSpecifier("_superior_")


### PR DESCRIPTION
This is a small change that should save a couple of hundred bytes of ram per `self._superior_` attribute specifier.
tested quickly on a watch