### PR TITLE
fix progress-bar padding

### DIFF
--- a/drive-contents/tg_gui_platform/progress_bar.py
+++ b/drive-contents/tg_gui_platform/progress_bar.py
@@ -58,9 +58,9 @@ class ProgressBar(Widget):
             )
         else:
             self._group = group = imple.ProgressBar(
-                x=rx + radius,
+                x=rx,
                 y=ry + ph // 2 - 6,
-                width=pw - 2 * radius,
+                width=pw,
                 height=12,
                 progress=0.0,
                 stroke=1,


### PR DESCRIPTION
This removes the left and right padding from the progress bar class. It is due for a refactor but all the widgets in the platform library will have a refractor when styling in introduced.